### PR TITLE
#1658 - add RabbitMQ config in properties

### DIFF
--- a/rabbitmq-consumer/src/main/java/com/api/config/RabbitConfig.java
+++ b/rabbitmq-consumer/src/main/java/com/api/config/RabbitConfig.java
@@ -13,6 +13,7 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static com.api.env.resources.AppResources.*;
 import static java.util.Arrays.asList;
 import static org.springframework.amqp.core.BindingBuilder.bind;
 
@@ -20,13 +21,6 @@ import static org.springframework.amqp.core.BindingBuilder.bind;
 @Configuration
 public class RabbitConfig {
 
-    public static final String DIRECT_QUEUE = "directQueue";
-    public static final String FANOUT_QUEUE = "fanoutQueue";
-    public static final String FANOUT_DLQ = "fanoutDeadLetterQueue";
-    public static final String EXCHANGE_DIRECT = "exchangeDirect";
-    public static final String EXCHANGE_FANOUT = "exchangeFanout";
-    public static final String EXCHANGE_FANOUT_DEAD_LETTER = "exchangeFanoutDeadLetter";
-    public static final String ROUTING_A = "routingA";
 
     @Bean
     public RabbitAdmin createAdmin() {
@@ -37,39 +31,39 @@ public class RabbitConfig {
 
     @Bean
     Queue queueDirect() {
-        return QueueBuilder.durable(DIRECT_QUEUE).build();
+        return QueueBuilder.durable(RABBITMQ_DIRECT_QUEUE.value()).build();
     }
 
     @Bean
     Queue queueFanout() {
-        return QueueBuilder.durable(FANOUT_QUEUE)
-                .withArgument("x-dead-letter-exchange", EXCHANGE_FANOUT_DEAD_LETTER)
+        return QueueBuilder.durable(RABBITMQ_EXCHANGE_FANOUT.value())
+                .withArgument("x-dead-letter-exchange", RABBITMQ_EXCHANGE_FANOUT_DL)
                 .build();
     }
 
     @Bean
     Queue fanoutDLQ() {
-        return QueueBuilder.durable(FANOUT_DLQ).build();
+        return QueueBuilder.durable(RABBITMQ_FANOUT_QUEUE_DL.value()).build();
     }
 
     @Bean
     DirectExchange directExchange() {
-        return new DirectExchange(EXCHANGE_DIRECT);
+        return new DirectExchange(RABBITMQ_EXCHANGE_DIRECT.value());
     }
 
     @Bean
     FanoutExchange fanoutExchange() {
-        return new FanoutExchange(EXCHANGE_FANOUT);
+        return new FanoutExchange(RABBITMQ_EXCHANGE_FANOUT.value());
     }
 
     @Bean
     FanoutExchange deadLetterFanoutExchange() {
-        return new FanoutExchange(EXCHANGE_FANOUT_DEAD_LETTER);
+        return new FanoutExchange(RABBITMQ_EXCHANGE_FANOUT_DL.value());
     }
 
     @Bean
     Binding bindingDirect() {
-        return bind(queueDirect()).to(directExchange()).with(ROUTING_A);
+        return bind(queueDirect()).to(directExchange()).with(RABBITMQ_DIRECT_ROUTING_KEY);
     }
 
     @Bean
@@ -89,9 +83,9 @@ public class RabbitConfig {
 
     @Bean
     public ConnectionFactory connectionFactory() {
-        CachingConnectionFactory connectionFactory = new CachingConnectionFactory("localhost");
-        connectionFactory.setUsername("guest");
-        connectionFactory.setPassword("guest");
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory(RABBITMQ_HOST.value().toString());
+        connectionFactory.setUsername(RABBITMQ_USERNAME.value());
+        connectionFactory.setPassword(RABBITMQ_PASSWORD.value());
         return connectionFactory;
     }
 
@@ -103,11 +97,11 @@ public class RabbitConfig {
     }
 
     @Bean
-    public RabbitListenerContainerFactory rabbitListenerContainerFactory(ConnectionFactory connectionFactory) {
+    public RabbitListenerContainerFactory rabbitListenerContainerFactory(final ConnectionFactory connectionFactory) {
         final SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
         factory.setMessageConverter(converter());
-        factory.setMaxConcurrentConsumers(5);
+        factory.setMaxConcurrentConsumers(RABBITMQ_MAX_CONSUMERS.value());
         return factory;
     }
 

--- a/rabbitmq-consumer/src/main/java/com/api/config/RabbitConfig.java
+++ b/rabbitmq-consumer/src/main/java/com/api/config/RabbitConfig.java
@@ -10,6 +10,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -21,7 +22,7 @@ import static org.springframework.amqp.core.BindingBuilder.bind;
 @Configuration
 public class RabbitConfig {
 
-
+    private AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
     @Bean
     public RabbitAdmin createAdmin() {
         final RabbitAdmin admin = new RabbitAdmin(connectionFactory());
@@ -37,12 +38,12 @@ public class RabbitConfig {
     @Bean
     Queue queueFanout() {
         return QueueBuilder.durable(RABBITMQ_EXCHANGE_FANOUT.value())
-                .withArgument("x-dead-letter-exchange", RABBITMQ_EXCHANGE_FANOUT_DL)
+                .withArgument("x-dead-letter-exchange", RABBITMQ_EXCHANGE_FANOUT_DL.value())
                 .build();
     }
 
     @Bean
-    Queue fanoutDLQ() {
+    Queue fanoutDlq() {
         return QueueBuilder.durable(RABBITMQ_FANOUT_QUEUE_DL.value()).build();
     }
 
@@ -63,7 +64,7 @@ public class RabbitConfig {
 
     @Bean
     Binding bindingDirect() {
-        return bind(queueDirect()).to(directExchange()).with(RABBITMQ_DIRECT_ROUTING_KEY);
+        return bind(queueDirect()).to(directExchange()).with(RABBITMQ_DIRECT_ROUTING_KEY.value().toString());
     }
 
     @Bean
@@ -73,7 +74,7 @@ public class RabbitConfig {
 
     @Bean
     Binding bindingFanoutDLQ() {
-        return bind(fanoutDLQ()).to(deadLetterFanoutExchange());
+        return bind(fanoutDlq()).to(deadLetterFanoutExchange());
     }
 
     @Bean
@@ -106,7 +107,7 @@ public class RabbitConfig {
     }
 
     private void declareAll(final RabbitAdmin admin) {
-        asList(queueDirect(), queueFanout(), fanoutDLQ())
+        asList(queueDirect(), queueFanout(), fanoutDlq())
                 .forEach(admin::declareQueue);
         asList(directExchange(), fanoutExchange(), deadLetterFanoutExchange())
                 .forEach(admin::declareExchange);

--- a/rabbitmq-consumer/src/main/java/com/api/env/resources/AppResources.java
+++ b/rabbitmq-consumer/src/main/java/com/api/env/resources/AppResources.java
@@ -103,6 +103,26 @@ public enum AppResources {
         public String value() {
             return Environment.getProperty("RABBITMQ_DIRECT_ROUTING_KEY_DL", configuration.getPropertyAsString("app.rabbitmq.direct.routingKey.dl"));
         }
+    },
+    RABBITMQ_HOST {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_HOST", configuration.getPropertyAsString("app.rabbitmq.host"));
+        }
+    },
+    RABBITMQ_USERNAME {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_USERNAME", configuration.getPropertyAsString("app.rabbitmq.username"));
+        }
+    },
+    RABBITMQ_PASSWORD {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_PASSWORD", configuration.getPropertyAsString("app.rabbitmq.password"));
+        }
+    },
+    RABBITMQ_MAX_CONSUMERS {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_MAX_CONSUMERS", configuration.getPropertyAsString("app.rabbitmq.max.consumers"));
+        }
     };
     private static final com.util.cloud.Configuration configuration = ConfigurationManager.getConfiguration();
 

--- a/rabbitmq-consumer/src/main/java/com/api/env/resources/AppResources.java
+++ b/rabbitmq-consumer/src/main/java/com/api/env/resources/AppResources.java
@@ -53,9 +53,59 @@ public enum AppResources {
         public String value() {
             return Environment.getProperty("APP_URL", configuration.getPropertyAsString("app.url")) + "/otp-login";
         }
+    },
+    RABBITMQ_EXCHANGE_DIRECT {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_EXCHANGE_DIRECT", configuration.getPropertyAsString("app.rabbitmq.exchange.direct"));
+        }
+    },
+    RABBITMQ_EXCHANGE_DIRECT_DL {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_EXCHANGE_DIRECT_DL", configuration.getPropertyAsString("app.rabbitmq.exchange.direct.dl"));
+        }
+    },
+    RABBITMQ_EXCHANGE_FANOUT {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_EXCHANGE_FANOUT", configuration.getPropertyAsString("app.rabbitmq.exchange.fanout"));
+        }
+    },
+    RABBITMQ_EXCHANGE_FANOUT_DL {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_EXCHANGE_FANOUT_DL", configuration.getPropertyAsString("app.rabbitmq.exchange.fanout.dl"));
+        }
+    },
+    RABBITMQ_DIRECT_QUEUE {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_DIRECT_QUEUE", configuration.getPropertyAsString("app.rabbitmq.direct.queue"));
+        }
+    },
+    RABBITMQ_DIRECT_QUEUE_DL {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_DIRECT_QUEUE_DL", configuration.getPropertyAsString("app.rabbitmq.direct.queue.dl"));
+        }
+    },
+    RABBITMQ_FANOUT_QUEUE {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_FANOUT_QUEUE", configuration.getPropertyAsString("app.rabbitmq.fanout.queue"));
+        }
+    },
+    RABBITMQ_FANOUT_QUEUE_DL {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_FANOUT_QUEUE_DL", configuration.getPropertyAsString("app.rabbitmq.fanout.queue.dl"));
+        }
+    },
+    RABBITMQ_DIRECT_ROUTING_KEY {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_DIRECT_ROUTING_KEY", configuration.getPropertyAsString("app.rabbitmq.direct.routingKey"));
+        }
+    },
+    RABBITMQ_DIRECT_ROUTING_KEY_DL {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_DIRECT_ROUTING_KEY_DL", configuration.getPropertyAsString("app.rabbitmq.direct.routingKey.dl"));
+        }
     };
     private static final com.util.cloud.Configuration configuration = ConfigurationManager.getConfiguration();
 
     public abstract <T> T value();
-	
-    }
+
+}

--- a/rabbitmq-consumer/src/main/java/com/api/env/resources/AppResources.java
+++ b/rabbitmq-consumer/src/main/java/com/api/env/resources/AppResources.java
@@ -120,8 +120,8 @@ public enum AppResources {
         }
     },
     RABBITMQ_MAX_CONSUMERS {
-        public String value() {
-            return Environment.getProperty("RABBITMQ_MAX_CONSUMERS", configuration.getPropertyAsString("app.rabbitmq.max.consumers"));
+        public Integer value() {
+            return Environment.getProperty("RABBITMQ_MAX_CONSUMERS", configuration.getPropertyAsInteger("app.rabbitmq.max.consumers"));
         }
     };
     private static final com.util.cloud.Configuration configuration = ConfigurationManager.getConfiguration();

--- a/rabbitmq-consumer/src/main/java/com/api/service/ConsumerService.java
+++ b/rabbitmq-consumer/src/main/java/com/api/service/ConsumerService.java
@@ -5,7 +5,6 @@ import org.slf4j.Logger;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
-import static com.api.config.RabbitConfig.*;
 import static org.slf4j.LoggerFactory.getLogger;
 
 @Component
@@ -13,13 +12,13 @@ public class ConsumerService {
 
     private static final Logger LOG = getLogger(ConsumerService.class);
 
-    @RabbitListener(queues = {DIRECT_QUEUE, FANOUT_QUEUE})
+    @RabbitListener(queues = {"${app.rabbitmq.direct.queue}", "${app.rabbitmq.fanout.queue}"})
     private void receiveMessage(final Message message) {
         LOG.info("Received message={}", message);
         throw new RuntimeException("Failed");
     }
 
-    @RabbitListener(queues = FANOUT_DLQ)
+    @RabbitListener(queues = "${app.rabbitmq.fanout.queue.dl}")
     private void processFailedMessages(final Message message) {
         LOG.info("Received failed message={}", message);
     }

--- a/rabbitmq-consumer/src/main/java/com/api/service/ConsumerService.java
+++ b/rabbitmq-consumer/src/main/java/com/api/service/ConsumerService.java
@@ -12,13 +12,12 @@ public class ConsumerService {
 
     private static final Logger LOG = getLogger(ConsumerService.class);
 
-    @RabbitListener(queues = {"${app.rabbitmq.direct.queue}", "${app.rabbitmq.fanout.queue}"})
+    @RabbitListener(queues = {"#{queueDirect.name}", "#{queueFanout.name}"})
     private void receiveMessage(final Message message) {
         LOG.info("Received message={}", message);
-        throw new RuntimeException("Failed");
     }
 
-    @RabbitListener(queues = "${app.rabbitmq.fanout.queue.dl}")
+    @RabbitListener(queues = "#{fanoutDlq.name}")
     private void processFailedMessages(final Message message) {
         LOG.info("Received failed message={}", message);
     }

--- a/rabbitmq-consumer/src/main/resources/application.properties
+++ b/rabbitmq-consumer/src/main/resources/application.properties
@@ -2,9 +2,15 @@ db.hostname=jdbc:postgresql://46.101.102.44/micro_service_reference_project
 db.user=postgres
 db.password=essentialprogramming
 
-#RabbitMQ Config
-app.rabbitmq.exchange.direct=directExchange
-app.rabbitmq.exchange.fanout=fanoutExchange
-app.rabbitmq.exchange.direct.routing=routingA
-app.rabbitmq.queue.direct=queue
-app.rabbitmq.queue.fanout=fanoutQueue
+# RabbitMQ Config
+app.rabbitmq.exchange.direct=exchangeDirect
+app.rabbitmq.exchange.direct.dl=exchangeDirectDeadLetter
+app.rabbitmq.exchange.fanout=exchangeFanout
+app.rabbitmq.exchange.fanout.dl=exchangeFanoutDeadLetter
+
+app.rabbitmq.direct.queue=${RABBITMQ_DIRECT_QUEUE:directQueue}
+app.rabbitmq.direct.queue.dl=${RABBITMQ_DIRECT_QUEUE_DL:directDeadLetterQueue}
+app.rabbitmq.fanout.queue=${RABBITMQ_FANOUT_QUEUE:fanoutQueue}
+app.rabbitmq.fanout.queue.dl=${RABBITMQ_FANOUT_QUEUE_DL:fanoutDeadLetterQueue}
+app.rabbitmq.direct.routingKey=${RABBITMQ_DIRECT_ROUTING_KEY:SPRINGBOOT_RABBITMQ_CONSUMER}
+app.rabbitmq.direct.routingKey.dl=${RABBITMQ_DIRECT_ROUTING_KEY_DL:deadLetterKey}

--- a/rabbitmq-consumer/src/main/resources/application.properties
+++ b/rabbitmq-consumer/src/main/resources/application.properties
@@ -8,9 +8,14 @@ app.rabbitmq.exchange.direct.dl=exchangeDirectDeadLetter
 app.rabbitmq.exchange.fanout=exchangeFanout
 app.rabbitmq.exchange.fanout.dl=exchangeFanoutDeadLetter
 
-app.rabbitmq.direct.queue=${RABBITMQ_DIRECT_QUEUE:directQueue}
-app.rabbitmq.direct.queue.dl=${RABBITMQ_DIRECT_QUEUE_DL:directDeadLetterQueue}
-app.rabbitmq.fanout.queue=${RABBITMQ_FANOUT_QUEUE:fanoutQueue}
-app.rabbitmq.fanout.queue.dl=${RABBITMQ_FANOUT_QUEUE_DL:fanoutDeadLetterQueue}
-app.rabbitmq.direct.routingKey=${RABBITMQ_DIRECT_ROUTING_KEY:SPRINGBOOT_RABBITMQ_CONSUMER}
-app.rabbitmq.direct.routingKey.dl=${RABBITMQ_DIRECT_ROUTING_KEY_DL:deadLetterKey}
+app.rabbitmq.direct.queue=directQueue
+app.rabbitmq.direct.queue.dl=directDeadLetterQueue
+app.rabbitmq.fanout.queue=fanoutQueue
+app.rabbitmq.fanout.queue.dl=fanoutDeadLetterQueue
+app.rabbitmq.direct.routingKey=RABBITMQ_CONSUMER
+app.rabbitmq.direct.routingKey.dl=deadLetterKey
+
+app.rabbitmq.host=localhost
+app.rabbitmq.username=guest
+app.rabbitmq.password=guest
+app.rabbitmq.max.consumers=5

--- a/rabbitmq-producer/src/main/java/com/api/config/RabbitConfig.java
+++ b/rabbitmq-producer/src/main/java/com/api/config/RabbitConfig.java
@@ -52,9 +52,9 @@ public class RabbitConfig {
 
     @Bean
     public ConnectionFactory connectionFactory() {
-        CachingConnectionFactory connectionFactory = new CachingConnectionFactory("localhost");
-        connectionFactory.setUsername("guest");
-        connectionFactory.setPassword("guest");
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory(RABBITMQ_HOST.value().toString());
+        connectionFactory.setUsername(RABBITMQ_USERNAME.value());
+        connectionFactory.setPassword(RABBITMQ_PASSWORD.value());
         return connectionFactory;
     }
 

--- a/rabbitmq-producer/src/main/java/com/api/config/RabbitConfig.java
+++ b/rabbitmq-producer/src/main/java/com/api/config/RabbitConfig.java
@@ -14,15 +14,12 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static com.api.env.resources.AppResources.*;
 import static java.util.Arrays.asList;
 
 @EnableRabbit
 @Configuration
 public class RabbitConfig {
-
-    public final String EXCHANGE_DIRECT = "exchangeDirect";
-    public final String EXCHANGE_FANOUT = "exchangeFanout";
-    public final String EXCHANGE_FANOUT_DEAD_LETTER = "exchangeFanoutDeadLetter";
 
     @Bean
     public RabbitAdmin createAdmin() {
@@ -35,17 +32,17 @@ public class RabbitConfig {
 
     @Bean
     DirectExchange directExchange() {
-        return new DirectExchange(EXCHANGE_DIRECT);
+        return new DirectExchange(RABBITMQ_EXCHANGE_DIRECT.value());
     }
 
     @Bean
     FanoutExchange fanoutExchange() {
-        return new FanoutExchange(EXCHANGE_FANOUT);
+        return new FanoutExchange(RABBITMQ_EXCHANGE_FANOUT.value());
     }
 
     @Bean
     FanoutExchange deadLetterFanoutExchange() {
-        return new FanoutExchange(EXCHANGE_FANOUT_DEAD_LETTER);
+        return new FanoutExchange(RABBITMQ_EXCHANGE_FANOUT_DL.value());
     }
 
     @Bean

--- a/rabbitmq-producer/src/main/java/com/api/env/resources/AppResources.java
+++ b/rabbitmq-producer/src/main/java/com/api/env/resources/AppResources.java
@@ -90,8 +90,8 @@ public enum AppResources {
         }
     },
     RABBITMQ_MAX_CONSUMERS {
-        public String value() {
-            return Environment.getProperty("RABBITMQ_MAX_CONSUMERS", configuration.getPropertyAsString("app.rabbitmq.max.consumers"));
+        public Integer value() {
+            return Environment.getProperty("RABBITMQ_MAX_CONSUMERS", configuration.getPropertyAsInteger("app.rabbitmq.max.consumers"));
         }
     };
     private static final com.util.cloud.Configuration configuration = ConfigurationManager.getConfiguration();

--- a/rabbitmq-producer/src/main/java/com/api/env/resources/AppResources.java
+++ b/rabbitmq-producer/src/main/java/com/api/env/resources/AppResources.java
@@ -53,9 +53,29 @@ public enum AppResources {
         public String value() {
             return Environment.getProperty("APP_URL", configuration.getPropertyAsString("app.url")) + "/otp-login";
         }
+    },
+    RABBITMQ_EXCHANGE_DIRECT {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_EXCHANGE_DIRECT", configuration.getPropertyAsString("app.rabbitmq.exchange.direct"));
+        }
+    },
+    RABBITMQ_EXCHANGE_DIRECT_DL {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_EXCHANGE_DIRECT_DL", configuration.getPropertyAsString("app.rabbitmq.exchange.direct.dl"));
+        }
+    },
+    RABBITMQ_EXCHANGE_FANOUT {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_EXCHANGE_FANOUT", configuration.getPropertyAsString("app.rabbitmq.exchange.fanout"));
+        }
+    },
+    RABBITMQ_EXCHANGE_FANOUT_DL {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_EXCHANGE_FANOUT_DL", configuration.getPropertyAsString("app.rabbitmq.exchange.fanout.dl"));
+        }
     };
     private static final com.util.cloud.Configuration configuration = ConfigurationManager.getConfiguration();
 
     public abstract <T> T value();
-	
-    }
+
+}

--- a/rabbitmq-producer/src/main/java/com/api/env/resources/AppResources.java
+++ b/rabbitmq-producer/src/main/java/com/api/env/resources/AppResources.java
@@ -73,6 +73,26 @@ public enum AppResources {
         public String value() {
             return Environment.getProperty("RABBITMQ_EXCHANGE_FANOUT_DL", configuration.getPropertyAsString("app.rabbitmq.exchange.fanout.dl"));
         }
+    },
+    RABBITMQ_HOST {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_HOST", configuration.getPropertyAsString("app.rabbitmq.host"));
+        }
+    },
+    RABBITMQ_USERNAME {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_USERNAME", configuration.getPropertyAsString("app.rabbitmq.username"));
+        }
+    },
+    RABBITMQ_PASSWORD {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_PASSWORD", configuration.getPropertyAsString("app.rabbitmq.password"));
+        }
+    },
+    RABBITMQ_MAX_CONSUMERS {
+        public String value() {
+            return Environment.getProperty("RABBITMQ_MAX_CONSUMERS", configuration.getPropertyAsString("app.rabbitmq.max.consumers"));
+        }
     };
     private static final com.util.cloud.Configuration configuration = ConfigurationManager.getConfiguration();
 

--- a/rabbitmq-producer/src/main/resources/application.properties
+++ b/rabbitmq-producer/src/main/resources/application.properties
@@ -7,3 +7,8 @@ app.rabbitmq.exchange.direct=exchangeDirect
 app.rabbitmq.exchange.direct.dl=exchangeDirectDeadLetter
 app.rabbitmq.exchange.fanout=exchangeFanout
 app.rabbitmq.exchange.fanout.dl=exchangeFanoutDeadLetter
+
+app.rabbitmq.host=localhost
+app.rabbitmq.username=guest
+app.rabbitmq.password=guest
+app.rabbitmq.max.consumers=5

--- a/rabbitmq-producer/src/main/resources/application.properties
+++ b/rabbitmq-producer/src/main/resources/application.properties
@@ -1,3 +1,9 @@
 db.hostname=jdbc:postgresql://46.101.102.44/micro_service_reference_project
 db.user=postgres
 db.password=essentialprogramming
+
+# RabbitMQ Config
+app.rabbitmq.exchange.direct=exchangeDirect
+app.rabbitmq.exchange.direct.dl=exchangeDirectDeadLetter
+app.rabbitmq.exchange.fanout=exchangeFanout
+app.rabbitmq.exchange.fanout.dl=exchangeFanoutDeadLetter

--- a/spring-boot-rabbitmq-consumer/src/main/java/com/rabbitmq/config/RabbitConfig.java
+++ b/spring-boot-rabbitmq-consumer/src/main/java/com/rabbitmq/config/RabbitConfig.java
@@ -3,6 +3,7 @@ package com.rabbitmq.config;
 import org.springframework.amqp.core.*;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,69 +12,80 @@ import static org.springframework.amqp.core.BindingBuilder.bind;
 @Configuration
 public class RabbitConfig {
 
-    public static final String DIRECT_QUEUE = "directQueue";
-    public static final String DIRECT_DLQ = "directDeadLetterQueue";
-    public static final String FANOUT_QUEUE = "fanoutQueue";
-    public static final String FANOUT_DLQ = "fanoutDeadLetterQueue";
-    public static final String EXCHANGE_DIRECT = "exchangeDirect";
-    public static final String EXCHANGE_FANOUT = "exchangeFanout";
-    public static final String EXCHANGE_FANOUT_DEAD_LETTER = "exchangeFanoutDeadLetter";
-    public static final String EXCHANGE_DIRECT_DEAD_LETTER = "exchangeDirectDeadLetter";
-    public static final String DLQ_ROUTING_KEY = "deadLetterKey";
+    @Value("${app.rabbitmq.exchange.direct}")
+    private String exchangeDirect;
+    @Value("${app.rabbitmq.exchange.fanout}")
+    private String exchangeFanout;
+    @Value("${app.rabbitmq.exchange.direct.dl}")
+    private String exchangeDirectDL;
+    @Value("${app.rabbitmq.exchange.fanout.dl}")
+    private String exchangeFanoutDL;
+    @Value("${app.rabbitmq.direct.queue}")
+    private String directQueue;
+    @Value("${app.rabbitmq.direct.queue.dl}")
+    private String directDLQ;
+    @Value("${app.rabbitmq.fanout.queue}")
+    private String fanoutQueue;
+    @Value("${app.rabbitmq.fanout.queue.dl}")
+    private String fanoutDLQ;
+    @Value("${app.rabbitmq.direct.routingKey}")
+    private String routingKey;
+    @Value("${app.rabbitmq.direct.routingKey.dl}")
+    private String routingKeyDL;
 
     @Bean
-    Queue queueA(){
-        return QueueBuilder.durable(DIRECT_QUEUE)
-                .withArgument("x-dead-letter-exchange", EXCHANGE_DIRECT_DEAD_LETTER)
-                .withArgument("x-dead-letter-routing-key", DLQ_ROUTING_KEY)
+    Queue queueDirect() {
+        return QueueBuilder.durable(directQueue)
+                .withArgument("x-dead-letter-exchange", exchangeDirectDL)
+                .withArgument("x-dead-letter-routing-key", routingKeyDL)
                 .build();
     }
 
     @Bean
-    Queue dlq() {
-        return QueueBuilder.durable(DIRECT_DLQ).build();
+    Queue directDLQ() {
+        return QueueBuilder.durable(directDLQ).build();
     }
 
     @Bean
     Queue queueFanout() {
-        return QueueBuilder.durable(FANOUT_QUEUE)
-                .withArgument("x-dead-letter-exchange", EXCHANGE_FANOUT_DEAD_LETTER)
+        return QueueBuilder.durable(fanoutQueue)
+                .withArgument("x-dead-letter-exchange", exchangeFanoutDL)
                 .build();
     }
 
     @Bean
     Queue fanoutDLQ() {
-        return QueueBuilder.durable(FANOUT_DLQ).build();
+        return QueueBuilder.durable(fanoutDLQ).build();
     }
 
     @Bean
     DirectExchange directExchange() {
-        return new DirectExchange(EXCHANGE_DIRECT);
+        return new DirectExchange(exchangeDirect);
     }
 
     @Bean
     DirectExchange deadLetterExchange() {
-        return new DirectExchange(EXCHANGE_DIRECT_DEAD_LETTER);
+        return new DirectExchange(exchangeDirectDL);
     }
 
     @Bean
     FanoutExchange fanoutExchange() {
-        return new FanoutExchange(EXCHANGE_FANOUT);
+        return new FanoutExchange(exchangeFanout);
     }
 
     @Bean
     FanoutExchange deadLetterFanoutExchange() {
-        return new FanoutExchange(EXCHANGE_FANOUT_DEAD_LETTER);
+        return new FanoutExchange(exchangeFanoutDL);
     }
 
     @Bean
     Binding bindingDirect() {
-        return bind(queueA()).to(directExchange()).with("SPRINGBOOT_RABBITMQ_CONSUMER");
+        return bind(queueDirect()).to(directExchange()).with(routingKey);
     }
 
     @Bean
     Binding bindingDirectDLQ() {
-        return bind(dlq()).to(deadLetterExchange()).with(DLQ_ROUTING_KEY);
+        return bind(directDLQ()).to(deadLetterExchange()).with(routingKeyDL);
     }
 
     @Bean

--- a/spring-boot-rabbitmq-consumer/src/main/java/com/rabbitmq/service/ConsumerService.java
+++ b/spring-boot-rabbitmq-consumer/src/main/java/com/rabbitmq/service/ConsumerService.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
-import static com.rabbitmq.config.RabbitConfig.*;
 import static org.slf4j.LoggerFactory.getLogger;
 
 @Component
@@ -14,14 +13,14 @@ public class ConsumerService {
 
     private static final Logger LOG = getLogger(ConsumerService.class);
 
-    @RabbitListener(queues = {DIRECT_QUEUE, FANOUT_QUEUE})
+    @RabbitListener(queues = {"${app.rabbitmq.direct.queue}", "${app.rabbitmq.fanout.queue}"})
     private void receive(final Message message) throws MessageException {
         LOG.info("Received message={}", message);
         if (message.getMessage().equals("string"))
             throw new MessageException();
     }
 
-    @RabbitListener(queues = {DIRECT_DLQ, FANOUT_DLQ})
+    @RabbitListener(queues = {"${app.rabbitmq.direct.queue.dl}", "${app.rabbitmq.fanout.queue.dl}"})
     private void processFailedMessages(final Message message) {
         LOG.info("Received failed message={}", message);
     }

--- a/spring-boot-rabbitmq-consumer/src/main/resources/application.properties
+++ b/spring-boot-rabbitmq-consumer/src/main/resources/application.properties
@@ -1,14 +1,19 @@
+server.port=8081
+
+# RabbitMQ Config
+app.rabbitmq.exchange.direct=${RABBITMQ_EXCHANGE_DIRECT:exchangeDirect}
+app.rabbitmq.exchange.direct.dl=${RABBITMQ_EXCHANGE_DIRECT_DL:exchangeDirectDeadLetter
+app.rabbitmq.exchange.fanout=${RABBITMQ_EXCHANGE_FANOUT:exchangeFanout}
+app.rabbitmq.exchange.fanout.dl=${RABBITMQ_EXCHANGE_FANOUT_DL:exchangeFanoutDeadLetter}
+app.rabbitmq.direct.queue=${RABBITMQ_DIRECT_QUEUE:directQueue}
+app.rabbitmq.direct.queue.dl=${RABBITMQ_DIRECT_QUEUE_DL:directDeadLetterQueue}
+app.rabbitmq.fanout.queue=${RABBITMQ_FANOUT_QUEUE:fanoutQueue}
+app.rabbitmq.fanout.queue.dl=${RABBITMQ_FANOUT_QUEUE_DL:fanoutDeadLetterQueue}
+app.rabbitmq.direct.routingKey=${RABBITMQ_DIRECT_ROUTING_KEY:SPRINGBOOT_RABBITMQ_CONSUMER}
+app.rabbitmq.direct.routingKey.dl=${RABBITMQ_DIRECT_ROUTING_KEY_DL:deadLetterKey}
+
 spring.rabbitmq.listener.simple.retry.enabled=true
 spring.rabbitmq.listener.simple.retry.initial-interval= 3s
 spring.rabbitmq.listener.simple.retry.max-attempts=3
 spring.rabbitmq.listener.simple.retry.max-interval=10s
 spring.rabbitmq.listener.simple.retry.multiplier=2
-
-server.port=8081
-
-#RabbitMQ Config
-app.rabbitmq.exchange.direct=directExchange
-app.rabbitmq.exchange.fanout=fanoutExchange
-app.rabbitmq.exchange.direct.routing=routingA
-app.rabbitmq.queue.direct=queue
-app.rabbitmq.queue.fanout=fanoutQueue

--- a/spring-boot-rabbitmq-consumer/src/main/resources/application.properties
+++ b/spring-boot-rabbitmq-consumer/src/main/resources/application.properties
@@ -5,12 +5,12 @@ app.rabbitmq.exchange.direct=${RABBITMQ_EXCHANGE_DIRECT:exchangeDirect}
 app.rabbitmq.exchange.direct.dl=${RABBITMQ_EXCHANGE_DIRECT_DL:exchangeDirectDeadLetter
 app.rabbitmq.exchange.fanout=${RABBITMQ_EXCHANGE_FANOUT:exchangeFanout}
 app.rabbitmq.exchange.fanout.dl=${RABBITMQ_EXCHANGE_FANOUT_DL:exchangeFanoutDeadLetter}
-app.rabbitmq.direct.queue=${RABBITMQ_DIRECT_QUEUE:directQueue}
+app.rabbitmq.direct.queue=${RABBITMQ_DIRECT_QUEUE:spring.boot.directQueue}
 app.rabbitmq.direct.queue.dl=${RABBITMQ_DIRECT_QUEUE_DL:directDeadLetterQueue}
 app.rabbitmq.fanout.queue=${RABBITMQ_FANOUT_QUEUE:fanoutQueue}
 app.rabbitmq.fanout.queue.dl=${RABBITMQ_FANOUT_QUEUE_DL:fanoutDeadLetterQueue}
 app.rabbitmq.direct.routingKey=${RABBITMQ_DIRECT_ROUTING_KEY:SPRINGBOOT_RABBITMQ_CONSUMER}
-app.rabbitmq.direct.routingKey.dl=${RABBITMQ_DIRECT_ROUTING_KEY_DL:deadLetterKey}
+app.rabbitmq.direct.routingKey.dl=${RABBITMQ_DIRECT_ROUTING_KEY_DL:spring.boot.deadLetterKey}
 
 spring.rabbitmq.listener.simple.retry.enabled=true
 spring.rabbitmq.listener.simple.retry.initial-interval= 3s

--- a/spring-boot-rabbitmq-producer/src/main/java/com/rabbitmq/config/RabbitConfig.java
+++ b/spring-boot-rabbitmq-producer/src/main/java/com/rabbitmq/config/RabbitConfig.java
@@ -6,35 +6,40 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class RabbitConfig {
 
-    public final String EXCHANGE_DIRECT = "exchangeDirect";
-    public final String EXCHANGE_FANOUT = "exchangeFanout";
-    public final String EXCHANGE_FANOUT_DEAD_LETTER = "exchangeFanoutDeadLetter";
-    public final String EXCHANGE_DIRECT_DEAD_LETTER = "exchangeDirectDeadLetter";
+    @Value("${app.rabbitmq.exchange.direct}")
+    private String exchangeDirect;
+    @Value("${app.rabbitmq.exchange.fanout}")
+    private String exchangeFanout;
+    @Value("${app.rabbitmq.exchange.direct.deadLetter}")
+    private String exchangeDirectDL;
+    @Value("${app.rabbitmq.exchange.fanout.deadLetter}")
+    private String exchangeFanoutDL;
 
     @Bean
     DirectExchange directExchange() {
-        return new DirectExchange(EXCHANGE_DIRECT);
+        return new DirectExchange(exchangeDirect);
     }
 
     @Bean
     DirectExchange deadLetterDirectExchange() {
-        return new DirectExchange(EXCHANGE_DIRECT_DEAD_LETTER);
+        return new DirectExchange(exchangeDirectDL);
     }
 
     @Bean
     FanoutExchange fanoutExchange() {
-        return new FanoutExchange(EXCHANGE_FANOUT);
+        return new FanoutExchange(exchangeFanout);
     }
 
     @Bean
     FanoutExchange deadLetterFanoutExchange() {
-        return new FanoutExchange(EXCHANGE_FANOUT_DEAD_LETTER);
+        return new FanoutExchange(exchangeFanoutDL);
     }
 
     @Bean

--- a/spring-boot-rabbitmq-producer/src/main/resources/application.properties
+++ b/spring-boot-rabbitmq-producer/src/main/resources/application.properties
@@ -1,2 +1,8 @@
 server.port=8082
 springdoc.swagger-ui.path=/apidoc
+
+# RabbitMQ Config
+app.rabbitmq.exchange.direct=${RABBITMQ_EXCHANGE_DIRECT:exchangeDirect}
+app.rabbitmq.exchange.direct.deadLetter=${RABBITMQ_EXCHANGE_DIRECT_DL:exchangeDirectDeadLetter
+app.rabbitmq.exchange.fanout=${RABBITMQ_EXCHANGE_FANOUT:exchangeFanout}
+app.rabbitmq.exchange.fanout.deadLetter=${RABBITMQ_EXCHANGE_FANOUT_DL:exchangeFanoutDeadLetter}


### PR DESCRIPTION
Added properties in `application.properties`. It will try to fetch values from `Environment` and default to existing ones in prop file.